### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: go
-
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.5
   - tip
+jobs:
+ exclude:
+  - arch: ppc64le
+    go: 1.5


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.